### PR TITLE
[Test] adding codeclimate support

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,13 @@
+--- 
+engines: 
+  fixme: 
+    enabled: true
+exclude_paths: 
+  - LICENSE
+  - README.md
+  - *.json
+  - jest.d.ts
+  - __*/*
+ratings: 
+  paths: 
+    - src/*

--- a/.npmignore
+++ b/.npmignore
@@ -6,6 +6,7 @@ coverage
 lcov.info
 tsconfig.json
 typings.json
+.codeclimate.yml
 .gitignore
 .npmignore
 jest.d.ts


### PR DESCRIPTION
Adding codeclimate support. `jest.d.ts` needs to be removed from `.codeclimate.yml` when DefinitelyTyped/DefinitelyTyped#11179 is merged.
